### PR TITLE
fix GetOperation understanding the result

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "apiserver",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "cmd/calculatord/main.go",
+            "env": {
+                "CALCULATORD_RABBIT_USER": "guest",
+                "CALCULATORD_RABBIT_PASS": "guest"
+            }
+        }
+    ]
+}

--- a/internal/apiserver/calculations_test.go
+++ b/internal/apiserver/calculations_test.go
@@ -134,11 +134,15 @@ func TestCalculations_GetOperation(t *testing.T) {
 	startedAt := time.Now().Add(-25 * time.Second)
 	opName := uuid.New().String()
 
-	fibOfResponse := &pb.FibonacciOfResponse{
-		First:       0,
-		Second:      1,
-		NthPosition: 6,
-		Result:      5,
+	fibOfResponse := store.FibonacciOfResult{
+		First:    0,
+		Second:   1,
+		Position: 6,
+		Result:   5,
+	}
+	fibOfResponseBytes, err := json.Marshal(fibOfResponse)
+	if err != nil {
+		t.Fatalf("unable to set up test with FibOfResponse raw json: %s", err)
 	}
 
 	retry := &errdetails.RetryInfo{RetryDelay: &durationpb.Duration{Seconds: 15}}
@@ -237,7 +241,7 @@ func TestCalculations_GetOperation(t *testing.T) {
 						Started: &startedAt,
 					},
 					Done:   true,
-					Result: fibOfResponse,
+					Result: fibOfResponseBytes,
 				}, nil
 			},
 			assert: func(t *testing.T, op *longrunningpb.Operation, err error) {
@@ -277,9 +281,9 @@ func TestCalculations_GetOperation(t *testing.T) {
 						fibOfResponse.Second,
 						actual.Second)
 				}
-				if actual.NthPosition != fibOfResponse.NthPosition {
+				if actual.NthPosition != fibOfResponse.Position {
 					t.Errorf("expected nth position to be %d but was %d",
-						fibOfResponse.NthPosition,
+						fibOfResponse.Position,
 						actual.NthPosition)
 				}
 				if actual.Result != fibOfResponse.Result {

--- a/internal/store/calculation.go
+++ b/internal/store/calculation.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"encoding/json"
 	"time"
 
 	"google.golang.org/genproto/googleapis/rpc/status"
@@ -16,13 +17,6 @@ type CalculationError struct {
 	Details []string `json:"details"` // todo: revisit this.
 }
 
-type FibonacciOfResult struct {
-	Position int64 `json:"position"`
-	First    int64 `json:"first"`
-	Second   int64 `json:"second"`
-	Result   int64 `json:"result"`
-}
-
 type Calculation struct {
 	Name     string              `json:"name"`
 	Metadata CalculationMetadata `json:"metadata"`
@@ -33,5 +27,12 @@ type Calculation struct {
 	Error *status.Status `json:"error,omitempty"`
 	// Response is mutually exclusive with Error. It should only be set whe done
 	// is true.
-	Result any `json:"result,omitempty"` // todo: could this instead use generics?
+	Result json.RawMessage `json:"result,omitempty"` // todo: could this instead use generics?
+}
+
+type FibonacciOfResult struct {
+	Position int64 `json:"position"`
+	First    int64 `json:"first"`
+	Second   int64 `json:"second"`
+	Result   int64 `json:"result"`
 }

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/vickleford/calculator/internal/calculators"
-	"github.com/vickleford/calculator/internal/pb"
 	"github.com/vickleford/calculator/internal/store"
 	"github.com/vickleford/calculator/internal/worker"
 	"google.golang.org/grpc/codes"
@@ -73,9 +72,9 @@ func TestFibOfWorker_Successful(t *testing.T) {
 		t.Fatalf("expected result to be set but it was nil")
 	}
 
-	res, ok := fakeStore.saved.Result.(*pb.FibonacciOfResponse)
-	if !ok {
-		t.Fatalf("result was an unexpected type: %T", fakeStore.saved.Result)
+	res := store.FibonacciOfResult{}
+	if err := json.Unmarshal(fakeStore.saved.Result, &res); err != nil {
+		t.Fatalf("unable to unmarshal result: %s", err)
 	}
 
 	if res.First != job.First {
@@ -86,8 +85,8 @@ func TestFibOfWorker_Successful(t *testing.T) {
 		t.Errorf("expected %d but got %d", job.Second, res.Second)
 	}
 
-	if res.NthPosition != job.Position {
-		t.Errorf("expected %d but got %d", job.Position, res.NthPosition)
+	if res.Position != job.Position {
+		t.Errorf("expected %d but got %d", job.Position, res.Position)
 	}
 
 	if res.Result != 3 {


### PR DESCRIPTION
The calculation result couldn't be understood by GetOperation because, being type any, it encoding/json unmarshaled it to a map[string]interface{}. This gets all the types lined up in a way that GetOperation can produce an intelligible result.