### PR TITLE
fix writing bug

### DIFF
--- a/internal/store/calculation.go
+++ b/internal/store/calculation.go
@@ -10,6 +10,9 @@ import (
 type CalculationMetadata struct {
 	Created time.Time  `json:"created"`
 	Started *time.Time `json:"started,omitempty"`
+
+	// Version carries the version identifier stored of the Calculation.
+	Version int64 `json:"-"`
 }
 
 type CalculationError struct {

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -19,6 +19,15 @@ type storeSpy struct {
 	setStartedName string
 	setStartedTime time.Time
 	setStartedErr  error
+
+	getFunc func(context.Context, string) (store.Calculation, error)
+}
+
+func (s *storeSpy) Get(ctx context.Context, name string) (store.Calculation, error) {
+	if s.getFunc == nil {
+		panic("unimplemented")
+	}
+	return s.getFunc(ctx, name)
 }
 
 func (s *storeSpy) SetStartedTime(ctx context.Context, name string, t time.Time) error {
@@ -43,6 +52,15 @@ func FibonacciOfJobJSON(t *testing.T, j worker.FibonacciOfJob) []byte {
 
 func TestFibOfWorker_Successful(t *testing.T) {
 	fakeStore := &storeSpy{}
+	fakeStore.getFunc = func(context.Context, string) (store.Calculation, error) {
+		return store.Calculation{
+			Name: "george",
+			Metadata: store.CalculationMetadata{
+				Created: time.Now(),
+				Version: 1,
+			},
+		}, nil
+	}
 
 	job := worker.FibonacciOfJob{
 		OperationName: "george",
@@ -96,6 +114,15 @@ func TestFibOfWorker_Successful(t *testing.T) {
 
 func TestFibOfWorker_Error(t *testing.T) {
 	fakeStore := &storeSpy{}
+	fakeStore.getFunc = func(context.Context, string) (store.Calculation, error) {
+		return store.Calculation{
+			Name: "george",
+			Metadata: store.CalculationMetadata{
+				Created: time.Now(),
+				Version: 1,
+			},
+		}, nil
+	}
 
 	job := worker.FibonacciOfJob{
 		OperationName: "george",
@@ -136,6 +163,15 @@ func TestFibOfWorker_Error(t *testing.T) {
 
 func TestFibOfWorker_SetsStartedTime(t *testing.T) {
 	fakeStore := &storeSpy{}
+	fakeStore.getFunc = func(context.Context, string) (store.Calculation, error) {
+		return store.Calculation{
+			Name: "george",
+			Metadata: store.CalculationMetadata{
+				Created: time.Now(),
+				Version: 1,
+			},
+		}, nil
+	}
 
 	job := worker.FibonacciOfJob{
 		OperationName: "george",


### PR DESCRIPTION
Fix a bug where the worker would overwrite the existing Calculation with one it "imagined." Instead, it gets what exists in the store and then patches in the values it wants to change before saving. It guarantees the version it updates is the version it got.